### PR TITLE
Add allowed_mgmt_cidr to default VPC build.

### DIFF
--- a/deployment/main.tf
+++ b/deployment/main.tf
@@ -57,6 +57,8 @@ module "vpc" {
   vpc_db_network_name = "database-network"
   vpc_db_subnet_cidr  = "10.5.3.0/24"
   vpc_db_subnet_name  = "database-subnet"
+
+  allowed_mgmt_cidr = var.allowed_mgmt_cidr
 }
 
 module "web" {

--- a/deployment/modules/vpc/main.tf
+++ b/deployment/modules/vpc/main.tf
@@ -86,7 +86,7 @@ resource "google_compute_firewall" "mgmt-allow-inbound" {
     ports    = ["443", "22"]
   }
 
-  source_ranges = ["0.0.0.0/0"]
+  source_ranges = [var.allowed_mgmt_cidr]
 }
 
 resource "google_compute_firewall" "untrust-allow-inbound" {

--- a/deployment/modules/vpc/variables.tf
+++ b/deployment/modules/vpc/variables.tf
@@ -65,3 +65,9 @@ variable "vpc_db_subnet_cidr" {
 variable "vpc_db_subnet_name" {
   description = "Database subnet name"
 }
+
+variable "allowed_mgmt_cidr" {
+  description = "The source address that will be allowed to access the lab environment"
+  type        = string
+  default     = "0.0.0.0/0"
+}


### PR DESCRIPTION
The `allowed_mgmt_cidr` variable wasn't being used by the VPC module, and I'm getting a bunch of brute forces on my dev environment.  Default is still `0.0.0.0/0` if it's unspecified.
