### PR TITLE
Add required_providers blocks to the modules

### DIFF
--- a/configuration/modules/networking/versions.tf
+++ b/configuration/modules/networking/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    panos = {
+      source = "paloaltonetworks/panos"
+    }
+  }
+  required_version = ">= 0.12"
+}

--- a/configuration/modules/policies/versions.tf
+++ b/configuration/modules/policies/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    panos = {
+      source = "paloaltonetworks/panos"
+    }
+  }
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
## Description

Added required_providers code blocks to the modules, copied from versions.tf in the configuration directory above.

## Motivation and Context

Fixes a problem experienced today during lab test-run, where Terraform would not execute without the required_providers explicitly defined within the module's HCL code.

## How Has This Been Tested?

Tested live in a Qwiklabs lab today.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [n/a] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [n/a] I have added tests to cover my changes if appropriate.
- [n/a] All new and existing tests passed.