### PR TITLE
Doc update to avoid students incorrectly copy-pasting

### DIFF
--- a/docs/02-configure/configure.rst
+++ b/docs/02-configure/configure.rst
@@ -84,7 +84,7 @@ Now, you should see the variables exported in your shell, which you can verify u
 
 .. code-block:: bash
 
-   PANOS_HOSTNAME=panorama.panlabs.org
+   PANOS_HOSTNAME=your-panorama-address
    PANOS_USERNAME=studentXX
    PANOS_PASSWORD=Ignite2020!
 


### PR DESCRIPTION
## Description

Small documentation update, replacing a "panlabs" address with a placeholder

## Motivation and Context

I experienced students copy and pasting the "panlabs" address when setting environment variables, so I suggest this change to avoid the scenario, given the Panorama used each workshop is likely to be different each time

## How Has This Been Tested?

No testing, documentation update

## Types of changes

Documentation update

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
