### PR TITLE
change debian version for web-vm and db-vm to debian-10

### DIFF
--- a/deployment/main.tf
+++ b/deployment/main.tf
@@ -63,7 +63,7 @@ module "web" {
   web_ssh_key      = "admin:${file(var.public_key_file)}"
   web_subnet_id    = module.vpc.web_subnet
   web_ip           = "10.5.2.5"
-  web_image        = "debian-9"
+  web_image        = "debian-10"
 }
 
 module "db" {
@@ -75,7 +75,7 @@ module "db" {
   db_ssh_key      = "admin:${file(var.public_key_file)}"
   db_subnet_id    = module.vpc.db_subnet
   db_ip           = "10.5.3.5"
-  db_image        = "debian-9"
+  db_image        = "debian-10"
 }
 
 ## Add firewall module here.


### PR DESCRIPTION
## Description

Changed the value of web_image and db_image on deployment/main.tf to "debian-10".

## Motivation and Context

GCP doesn't offer debian-9 image anymore.

## How Has This Been Tested?

I've tested that this is working by following the iac-terraform-workshop and confirming everything works as expected.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
